### PR TITLE
refactor: freeze all dataclasses

### DIFF
--- a/src/pocketeer/core/scoring.py
+++ b/src/pocketeer/core/scoring.py
@@ -1,6 +1,7 @@
 """Pocket creation, scoring, and management."""
 
 import logging
+from dataclasses import replace
 
 import biotite.structure as struc  # type: ignore
 import numpy as np
@@ -149,12 +150,11 @@ def create_pocket(
         spheres=pocket_spheres,
         centroid=centroid,
         volume=volume,
-        score=0.0,  # computed after creation
+        score=0.0,  # placeholder, filled below
         residues=residues,
         mask=mask,
     )
 
-    # Score the pocket
-    pocket.score = score_pocket(pocket)
-
-    return pocket
+    # Score the pocket and create final frozen instance
+    score = score_pocket(pocket)
+    return replace(pocket, score=score)

--- a/src/pocketeer/core/tessellation.py
+++ b/src/pocketeer/core/tessellation.py
@@ -1,5 +1,7 @@
 """Alpha-sphere computation, filtering, and sphere-specific operations."""
 
+from dataclasses import replace
+
 import biotite.structure as struc  # type: ignore
 import numpy as np
 import numpy.typing as npt
@@ -96,12 +98,14 @@ def label_polarity(
     sasa_values = sasa(atomarray, probe_radius=polar_probe_radius)
 
     # For each sphere, compute mean SASA of its 4 defining atoms
+    labeled_spheres = []
     for sphere in spheres:
         # Get SASA values for the atoms that define this sphere
         defining_sasa = sasa_values[sphere.atom_indices]
-        sphere.mean_sasa = float(np.mean(defining_sasa))
+        mean_sasa = float(np.mean(defining_sasa))
+        labeled_spheres.append(replace(sphere, mean_sasa=mean_sasa))
 
-    return spheres
+    return labeled_spheres
 
 
 def filter_surface_spheres(

--- a/src/pocketeer/core/types.py
+++ b/src/pocketeer/core/types.py
@@ -7,7 +7,7 @@ import numpy as np
 import numpy.typing as npt
 
 
-@dataclass
+@dataclass(frozen=True)
 class AlphaSphere:
     """Represents a single alpha-sphere from Delaunay tessellation.
 
@@ -32,7 +32,7 @@ class AlphaSphere:
         }
 
 
-@dataclass
+@dataclass(frozen=True)
 class Pocket:
     """Represents a detected pocket (cluster of alpha-spheres)."""
 


### PR DESCRIPTION
- Updated pocket creation to use a placeholder score, which is now computed before returning a frozen instance.
- Modified sphere labeling to create a new list of labeled spheres with computed mean SASA values, enhancing immutability with dataclass replacements.
- Changed dataclass definitions for AlphaSphere and Pocket to be frozen for better integrity.