### PR TITLE
docs: update installation instructions for `view_pockets()` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,15 @@ Pocketeer implements a simplified version of the fpocket algorithm:
 
 Pocketeer integrates smoothly with Jupyter and scientific Python notebooks. You can directly visualize detected pockets for rapid exploration:
 
+> **Note:** The `view_pockets()` function requires the optional `atomworks` dependency. Install it with:
+> ```bash
+> pip install pocketeer[vis]
+> ```
+> or
+> ```bash
+> uv add 'pocketeer[vis]'
+> ```
+
 ```python
 import pocketeer as pt
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -107,6 +107,16 @@ All parameters for `find_pockets()` can be passed directly as keyword arguments:
 Visualize protein structure with detected pockets in a Jupyter notebook or other supported viewer.
 This function is a wrapper around [atomworks.io.utils.visualize.view](https://baker-laboratory.github.io/atomworks-dev/latest/io/utils/visualize.html) and shows pockets as colored spheres.
 
+!!! note "Installation Required"
+    This function requires the `atomworks` package. Install with:
+    ```bash
+    pip install pocketeer[vis]
+    ```
+    or
+    ```bash
+    uv add 'pocketeer[vis]'
+    ```
+
 ```python
 pocketeer.view_pockets(
     atomarray,                     # biotite.structure.AtomArray with protein structure data
@@ -156,6 +166,4 @@ pockets = pt.find_pockets(atomarray)
 viewer = pt.view_pockets(atomarray, pockets)
 viewer.show()
 ```
-
-**Note:** Requires the `atomworks` package. Install with `pip install pocketeer[vis]`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -140,12 +140,19 @@ pt.write_summary("summary.txt", pockets, "protein.pdb")
 
 ### Visualize Results
 
+!!! note "Installation Required"
+    The `view_pockets()` function requires the optional `atomworks` dependency. Install it with:
+    ```bash
+    pip install pocketeer[vis]
+    ```
+    or
+    ```bash
+    uv add 'pocketeer[vis]'
+    ```
+
 ```python
-# If atomworks is installed
-try:
-    pt.view_pockets(atomarray, pockets)
-except ImportError:
-    print("Install atomworks for visualization: pip install pocketeer[vis]")
+# Visualize detected pockets
+pt.view_pockets(atomarray, pockets)
 ```
 
 ## Common Issues

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,6 +91,16 @@ Pocketeer implements a simplified version of the fpocket algorithm:
 
 Pocketeer integrates smoothly with Jupyter and scientific Python notebooks. You can directly visualize detected pockets for rapid exploration:
 
+!!! note "Installation Required"
+    The `view_pockets()` function requires the optional `atomworks` dependency. Install it with:
+    ```bash
+    pip install pocketeer[vis]
+    ```
+    or
+    ```bash
+    uv add 'pocketeer[vis]'
+    ```
+
 ```python
 import pocketeer as pt
 


### PR DESCRIPTION
Added notes across multiple documentation files to clarify that the `view_pockets()` function requires the optional `atomworks` dependency. Included installation commands for both pip and uv.